### PR TITLE
Update to use node 12.x and a more recent release of sharp

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM amazonlinux
 LABEL maintainer="devneko <dotneet@gmail.com>"
 RUN yum install -y gcc-c++ which zip && \
-    curl --silent --location https://rpm.nodesource.com/setup_8.x | bash - && \
+    curl --silent --location https://rpm.nodesource.com/setup_12.x | bash - && \
     yum install -y nodejs && \
     npm i -g yarn \
     yarn global add claudia

--- a/docker/create-lambda.sh
+++ b/docker/create-lambda.sh
@@ -4,7 +4,7 @@ claudia create \
         --region ${AWS_REGION} \
         --name ${LAMBDA_NAME} \
         --handler index.handler \
-        --runtime "nodejs8.10" \
+        --runtime "nodejs12.x" \
         --role ${LAMBDA_ROLE} \
         --memory ${LAMBDA_MEMORY} \
         --timeout ${LAMBDA_TIMEOUT} \

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "docker:destroy-lambda": "./docker/destroy-lambda.sh"
   },
   "dependencies": {
-    "aws-sdk": "^2.394.0",
-    "sharp": "^0.21.3"
+    "aws-sdk": "^2.814.0",
+    "sharp": "^0.26.3"
   },
   "devDependencies": {
-    "bluebird": "^3.5.3",
+    "bluebird": "^3.7.2",
     "claudia": "^5.3.0",
     "dotenv": "^6.2.0"
   }


### PR DESCRIPTION
This PR simply updates to a more recent version of nodejs and sharp. I found it necessary or otherwise I hit the error 

```
error semver@7.3.4: The engine "node" is incompatible with this module. Expected version ">=10". Got "8.17.0" error Found incompatible module.
```

and without an update of Sharp also hit an error like

```
gyp ERR! command "/usr/bin/node" "/usr/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /work/out/node_modules/sharp
gyp ERR! node -v v12.20.0
gyp ERR! node-gyp -v v5.1.0
gyp ERR! not ok
```

After updating as per this PR all worked well.